### PR TITLE
Correct docs links

### DIFF
--- a/src/cloudservices.js
+++ b/src/cloudservices.js
@@ -100,7 +100,7 @@ CloudServices.Token = Token;
  * if they should have access e.g. to upload files with Easy Image or to access the Collaboraation service.
  *
  * You can find more information about token endpoints in the
- * {@glink @cs guides/quick-start#create-token-endpoint Cloud Services - Quick start}
+ * {@glink @cs guides/easy-image/quick-start#create-token-endpoint Cloud Services - Quick start}
  * and {@glink @cs guides/token-endpoints/tokenendpoint Cloud Services - Creating token endpoint} documentation.
  *
  * Without a properly working token endpoint (token URL) CKEditor plugins will not be able to connect to CKEditor Cloud Services.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Correct docs link to point the user to the final page, without redirecting him. Closes #18 