### PR TITLE
Use `err.message` instead of `err.stack`

### DIFF
--- a/tests/manual/token.js
+++ b/tests/manual/token.js
@@ -27,8 +27,8 @@ ClassicEditor
 		window.editor = editor;
 	} )
 	.catch( err => {
-		output.innerText = err.stack;
-		console.error( err.stack );
+		output.innerText = err.message;
+		console.error( err.message );
 	} );
 
 function handleRequest( xhr, resolve, reject ) {

--- a/tests/manual/token.md
+++ b/tests/manual/token.md
@@ -19,4 +19,4 @@
 **Expected result**
 * Editor isn't initialized at the start of the scenario.
 * The token is different than the previous token.
-* After clicking the button the editor doesn't initialize and there is an error in the output - `Error: Cannot download new token!`.
+* After clicking the button the editor doesn't initialize and there is an error in the output - `Cannot download new token!`.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Used `err.message` instead of `err.stack` in manual tests. Closes #21.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
